### PR TITLE
fix #9 - remove strong type expected on pagination config fetch

### DIFF
--- a/src/Filters/FiltersSearchesThenExportsData.php
+++ b/src/Filters/FiltersSearchesThenExportsData.php
@@ -260,7 +260,7 @@ trait FiltersSearchesThenExportsData
      *
      * @return int
      */
-    protected function getPageSize(): int
+    protected function getPageSize()
     {
         return config('grids.pagination_limit');
     }


### PR DESCRIPTION
#9 will now use eloquent default if pagination not set