### PR TITLE
attempt rendering of the views using layouts to aid in customizability

### DIFF
--- a/src/Grid.php
+++ b/src/Grid.php
@@ -31,7 +31,8 @@ abstract class Grid implements Htmlable, GridInterface, GridButtonsInterface, Gr
         CreatesColumns,
         ConfiguresRoutes,
         AddsColumnFilters,
-        RendersButtons;
+        RendersButtons,
+        RendersGrid;
 
     /**
      * Specify if the rows on the table should be clicked to navigate to the record
@@ -39,13 +40,6 @@ abstract class Grid implements Htmlable, GridInterface, GridButtonsInterface, Gr
      * @var bool
      */
     protected $linkableRows = false;
-
-    /**
-     * Specify if the footer section needs to be displayed
-     *
-     * @var bool
-     */
-    protected $showFooter = false;
 
     /**
      * The id of the grid. Many grids can exist on the same page, but the ID has to be unique
@@ -118,13 +112,6 @@ abstract class Grid implements Htmlable, GridInterface, GridButtonsInterface, Gr
     protected $tableColumns = [];
 
     /**
-     * Controls rendering or not, for the search form
-     *
-     * @var bool
-     */
-    protected $shouldRenderSearchForm = true;
-
-    /**
      * Create the grid
      *
      * @param array $params
@@ -146,17 +133,6 @@ abstract class Grid implements Htmlable, GridInterface, GridButtonsInterface, Gr
         );
         $this->setGridDataItems($result);
 
-        return $this;
-    }
-
-    /**
-     * Define rendering of the search form
-     *
-     * @return GridInterface
-     */
-    public function withoutSearchForm(): GridInterface
-    {
-        $this->shouldRenderSearchForm = false;
         return $this;
     }
 
@@ -224,24 +200,6 @@ abstract class Grid implements Htmlable, GridInterface, GridButtonsInterface, Gr
     public function getName(): string
     {
         return $this->name;
-    }
-
-    /**
-     * If the grid should show a footer
-     *
-     * @return bool
-     */
-    public function shouldShowFooter(): bool
-    {
-        return $this->showFooter;
-    }
-
-    /**
-     * @param bool $showFooter
-     */
-    public function setShowFooter(bool $showFooter): void
-    {
-        $this->showFooter = $showFooter;
     }
 
     /**
@@ -318,37 +276,6 @@ abstract class Grid implements Htmlable, GridInterface, GridButtonsInterface, Gr
                 $this->data = $data;
             }
         }
-    }
-
-    /**
-     * Grid should render search form
-     *
-     * @return bool
-     */
-    public function shouldRenderSearchForm()
-    {
-        return $this->shouldRenderSearchForm;
-    }
-
-    /**
-     * Render the search form on the grid
-     *
-     * @return string
-     * @throws \Throwable
-     */
-    public function renderSearchForm()
-    {
-        $params = func_get_args();
-        $data = [
-            'colSize' => $this->getGridToolbarSize()[0], // size
-            'action' => $this->getSearchUrl(),
-            'id' => $this->getSearchFormId(),
-            'name' => $this->getGridSearchParam(),
-            'dataAttributes' => [],
-            'placeholder' => $this->getSearchPlaceholder(),
-        ];
-
-        return view($this->getGridSearchView(), array_merge($data, $params))->render();
     }
 
     /**
@@ -446,45 +373,6 @@ abstract class Grid implements Htmlable, GridInterface, GridButtonsInterface, Gr
     }
 
     /**
-     * Render the grid as HTML on the user defined view
-     *
-     * @return string
-     * @throws \Throwable
-     */
-    public function render()
-    {
-        return view($this->getGridView(), $this->compactData(func_get_args()))->render();
-    }
-
-    /**
-     * Specify the data to be sent to the view
-     *
-     * @param array $params
-     * @return array
-     * @throws \Exception
-     */
-    protected function compactData($params = [])
-    {
-        $data = [
-            'grid' => $this,
-            'columns' => $this->processColumns()
-        ];
-        return array_merge($data, $this->getExtraParams($params));
-    }
-
-    /**
-     * Any extra parameters that need to be passed to the grid
-     * $params is func_get_args() passed from render
-     *
-     * @param array $params
-     * @return array
-     */
-    public function getExtraParams($params)
-    {
-        return array_merge($this->extraParams, $params);
-    }
-
-    /**
      * Override this method and return a callback so that linkable rows are applied
      *
      * @return Closure
@@ -566,24 +454,5 @@ abstract class Grid implements Htmlable, GridInterface, GridButtonsInterface, Gr
     public function getHeaderClass(): string
     {
         return $this->getGridDefaultHeaderClass();
-    }
-
-    /**
-     * Pass the grid on to the user defined view e.g an index page, along with any data that may be required
-     * Will dynamically switch between displaying the grid and downloading exported files
-     *
-     * @param string $viewName the view name
-     * @param array $data any extra data to be sent to the view
-     * @param string $as the variable to be sent to the view, representing the grid
-     *
-     * @return \Illuminate\Contracts\View\Factory|\Illuminate\Http\Response|\Illuminate\View\View
-     * @throws \Throwable
-     */
-    public function renderOn(string $viewName, $data = [], $as = 'grid')
-    {
-        if ($this->getRequest()->has($this->getGridExportParam())) {
-            return $this->exportHandler->export();
-        }
-        return view($viewName, array_merge($data, [$as => $this]));
     }
 }

--- a/src/GridInterface.php
+++ b/src/GridInterface.php
@@ -16,9 +16,9 @@ interface GridInterface
      * Create the grid
      *
      * @param array $params
-     * @return GridInterface
+     * @return $this
      */
-    public function create(array $params): GridInterface;
+    public function create(array $params): self;
 
     /**
      * Initialize grid variables

--- a/src/HasGridConfigurations.php
+++ b/src/HasGridConfigurations.php
@@ -156,6 +156,19 @@ trait HasGridConfigurations
      */
     private $gridFooterClass;
 
+    /**
+     * @var string
+     */
+    private $gridTemplateView;
+
+    public function getGridTemplateView(): string
+    {
+        if ($this->gridTemplateView === null) {
+            $this->gridTemplateView = config('grid.templates.view', 'leantony::grid.templates.bs4-card');
+        }
+        return $this->gridTemplateView;
+    }
+
     public function getGridFooterClass(): string
     {
         if ($this->gridFooterClass === null) {

--- a/src/RendersGrid.php
+++ b/src/RendersGrid.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Copyright (c) 2018.
+ * @author Antony [leantony] Chacha
+ */
+
+namespace Leantony\Grid;
+
+trait RendersGrid
+{
+    /**
+     * Specify if the footer section needs to be displayed
+     *
+     * @var bool
+     */
+    protected $showFooter = false;
+
+    /**
+     * Controls rendering or not, for the search form
+     *
+     * @var bool
+     */
+    protected $shouldRenderSearchForm = true;
+
+    /**
+     * Controls rendering or not, for the grid filters, regardless of what is set on the columns
+     *
+     * @var bool
+     */
+    protected $shouldRenderFilters = true;
+
+    /**
+     * Controls if the grid needs to show a modal form when the rows are clicked
+     * Has no effect if $linkableRows is set to false
+     *
+     * @var bool
+     */
+    protected $shouldShowModalOnClickingRow = false;
+
+    /**
+     * If the grid should show a footer
+     *
+     * @return bool
+     */
+    public function shouldShowFooter(): bool
+    {
+        return $this->showFooter;
+    }
+
+    /**
+     * @param bool $showFooter
+     */
+    public function setShowFooter(bool $showFooter): void
+    {
+        $this->showFooter = $showFooter;
+    }
+
+    /**
+     * Define if the grid filters should be displayed for this grid
+     *
+     * @return bool
+     */
+    public function shouldRenderGridFilters(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Grid should render search form
+     *
+     * @return bool
+     */
+    public function shouldRenderSearchForm(): bool
+    {
+        return $this->shouldRenderSearchForm;
+    }
+
+    /**
+     * Define rendering of the search form
+     *
+     * @return GridInterface
+     */
+    public function withoutSearchForm()
+    {
+        $this->shouldRenderSearchForm = false;
+        return $this;
+    }
+
+    /**
+     * Grid should show the modal form when the rows are clicked on
+     * Works if the $linkableRows property is set to true
+     *
+     * @return bool
+     */
+    public function shouldShowModalOnClickingRow()
+    {
+        return $this->shouldShowModalOnClickingRow;
+    }
+
+    /**
+     * Get the rendering template/grid layout to use
+     *
+     * @return string
+     */
+    public function getRenderingTemplateToUse(): string
+    {
+        return $this->getGridTemplateView();
+    }
+
+    /**
+     * Render the grid title
+     *
+     * @return string
+     */
+    public function renderTitle(): string
+    {
+        return $this->getName();
+    }
+
+    /**
+     * Specify the data to be sent to the view
+     *
+     * @param array $params
+     * @return array
+     * @throws \Exception
+     */
+    protected function compactData($params = [])
+    {
+        $data = [
+            'grid' => $this,
+            'columns' => $this->processColumns()
+        ];
+        return array_merge($data, $this->getExtraParams($params));
+    }
+
+    /**
+     * Any extra parameters that need to be passed to the grid
+     * $params is func_get_args() passed from render
+     *
+     * @param array $params
+     * @return array
+     */
+    public function getExtraParams($params)
+    {
+        return array_merge($this->extraParams, $params);
+    }
+
+    /**
+     * Render the grid as HTML on the user defined view
+     *
+     * @return string
+     * @throws \Throwable
+     */
+    public function render()
+    {
+        return view($this->getGridView(), $this->compactData(func_get_args()))->render();
+    }
+
+    /**
+     * Pass the grid on to the user defined view e.g an index page, along with any data that may be required
+     * Will dynamically switch between displaying the grid and downloading exported files
+     *
+     * @param string $viewName the view name
+     * @param array $data any extra data to be sent to the view
+     * @param string $as the variable to be sent to the view, representing the grid
+     *
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\Http\Response|\Illuminate\View\View
+     * @throws \Throwable
+     */
+    public function renderOn(string $viewName, $data = [], $as = 'grid')
+    {
+        if ($this->getRequest()->has($this->getGridExportParam())) {
+            return $this->exportHandler->export();
+        }
+        return view($viewName, array_merge($data, [$as => $this]));
+    }
+
+    /**
+     * Render pagination info at the header of the user defined view
+     *
+     * @return string
+     * @throws \Throwable
+     */
+    public function renderPaginationInfoAtHeader()
+    {
+        return view('leantony::grid.pagination.pagination-info', [
+            'grid' => $this,
+            'direction' => 'right'
+        ])->render();
+    }
+
+    /**
+     * Render pagination info at the footer of the user defined view
+     *
+     * @return string
+     * @throws \Throwable
+     */
+    public function renderPaginationInfoAtFooter()
+    {
+        return view('leantony::grid.pagination.pagination-info', [
+            'grid' => $this,
+            'direction' => 'left',
+            'atFooter' => true
+        ])->render();
+    }
+
+    /**
+     * Render pagination links at the footer of the user defined view
+     *
+     * @return string
+     * @throws \Throwable
+     */
+    public function renderPaginationLinksSection()
+    {
+        return view('leantony::grid.pagination.pagination-links', [
+            'grid' => $this,
+        ])->render();
+    }
+
+    /**
+     * Render grid filter
+     *
+     * @return string
+     * @throws \Throwable
+     */
+    public function renderGridFilters()
+    {
+        return view('leantony::grid.filter', [
+            'grid' => $this,
+            'columns' => $this->getProcessedColumns(),
+            'formId' => $this->getFilterFormId()
+        ])->render();
+    }
+
+    /**
+     * Render the search form on the grid
+     *
+     * @return string
+     * @throws \Throwable
+     */
+    public function renderSearchForm()
+    {
+        $params = func_get_args();
+        $data = [
+            'colSize' => $this->getGridToolbarSize()[0], // size
+            'action' => $this->getSearchUrl(),
+            'id' => $this->getSearchFormId(),
+            'name' => $this->getGridSearchParam(),
+            'dataAttributes' => [],
+            'placeholder' => $this->getSearchPlaceholder(),
+        ];
+
+        return view($this->getGridSearchView(), array_merge($data, $params))->render();
+    }
+}

--- a/src/RendersGrid.php
+++ b/src/RendersGrid.php
@@ -86,9 +86,9 @@ trait RendersGrid
     /**
      * Define rendering of the search form
      *
-     * @return GridInterface
+     * @return $this
      */
-    public function withoutSearchForm(): GridInterface
+    public function withoutSearchForm(): self
     {
         $this->shouldRenderSearchForm = false;
         return $this;
@@ -98,9 +98,9 @@ trait RendersGrid
      * Define a custom layout/template to use when rendering the grid
      *
      * @param string $layout
-     * @return GridInterface
+     * @return $this
      */
-    public function withCustomTemplate(string $layout): GridInterface
+    public function withCustomTemplate(string $layout): self
     {
         $this->templateToUseForRendering = $layout;
         return $this;
@@ -109,9 +109,9 @@ trait RendersGrid
     /**
      * Define rendering of the filters
      *
-     * @return GridInterface
+     * @return $this
      */
-    public function withoutFilters(): GridInterface
+    public function withoutFilters(): self
     {
         $this->shouldRenderFilters = false;
         return $this;

--- a/src/RendersGrid.php
+++ b/src/RendersGrid.php
@@ -38,6 +38,14 @@ trait RendersGrid
     protected $shouldShowModalOnClickingRow = false;
 
     /**
+     * Controls the layout to use for rendering the grid.
+     * If not set, defaults to the default view set on config
+     *
+     * @var null|string
+     */
+    protected $templateToUseForRendering = null;
+
+    /**
      * If the grid should show a footer
      *
      * @return bool
@@ -62,7 +70,7 @@ trait RendersGrid
      */
     public function shouldRenderGridFilters(): bool
     {
-        return true;
+        return $this->shouldRenderFilters;
     }
 
     /**
@@ -80,9 +88,32 @@ trait RendersGrid
      *
      * @return GridInterface
      */
-    public function withoutSearchForm()
+    public function withoutSearchForm(): GridInterface
     {
         $this->shouldRenderSearchForm = false;
+        return $this;
+    }
+
+    /**
+     * Define a custom layout/template to use when rendering the grid
+     *
+     * @param string $layout
+     * @return GridInterface
+     */
+    public function withCustomTemplate(string $layout): GridInterface
+    {
+        $this->templateToUseForRendering = $layout;
+        return $this;
+    }
+
+    /**
+     * Define rendering of the filters
+     *
+     * @return GridInterface
+     */
+    public function withoutFilters(): GridInterface
+    {
+        $this->shouldRenderFilters = false;
         return $this;
     }
 
@@ -92,7 +123,7 @@ trait RendersGrid
      *
      * @return bool
      */
-    public function shouldShowModalOnClickingRow()
+    public function shouldShowModalOnClickingRow(): bool
     {
         return $this->shouldShowModalOnClickingRow;
     }
@@ -104,6 +135,9 @@ trait RendersGrid
      */
     public function getRenderingTemplateToUse(): string
     {
+        if ($this->templateToUseForRendering !== null && is_string($this->templateToUseForRendering)) {
+            return $this->templateToUseForRendering;
+        }
         return $this->getGridTemplateView();
     }
 
@@ -128,7 +162,7 @@ trait RendersGrid
     {
         $data = [
             'grid' => $this,
-            'columns' => $this->processColumns()
+            'columns' => $this->getProcessedColumns()
         ];
         return array_merge($data, $this->getExtraParams($params));
     }

--- a/src/resources/config/grid.php
+++ b/src/resources/config/grid.php
@@ -178,5 +178,15 @@ return [
             'password',
             'password_hash',
         ]
+    ],
+
+    /**
+     * Grid templates
+     */
+    'templates' => [
+        /**
+         * The view to use for the templates
+         */
+        'view' => 'leantony::grid.templates.bs4-card'
     ]
 ];

--- a/src/resources/views/grid/grid.blade.php
+++ b/src/resources/views/grid/grid.blade.php
@@ -1,199 +1,167 @@
-<div class="row laravel-grid" id="{{ $grid->getId() }}">
-    <div class="col-md-12 col-xs-12 col-sm-12">
-        <div class="card">
-            <div class="card-header">
-                <div class="pull-left">
-                    <h4 class="grid-title">{{ $grid->getName() }}</h4>
+@extends($grid->getRenderingTemplateToUse())
+@section('data')
+    <div class="row">
+        @if($grid->shouldRenderSearchForm())
+            {!! $grid->renderSearchForm() !!}
+        @endif
+
+        @if($grid->hasButtons('toolbar'))
+            <div class="col-md-{{ $grid->getGridToolbarSize()[1] }}">
+                <div class="pull-right">
+                    @foreach($grid->getButtons('toolbar') as $button)
+                        {!! $button->render() !!}
+                    @endforeach
                 </div>
-                <!-- pagination info -->
-            @include('leantony::grid.pagination.pagination-info', ['grid' => $grid, 'direction' => 'right'])
-            <!-- end pagination info -->
             </div>
-            <div class="card-body">
-                <!-- search form -->
-                <div class="row">
-                    @if($grid->shouldRenderSearchForm())
-                        {!! $grid->renderSearchForm() !!}
-                    @endif
-                <!-- toolbar buttons -->
-                    @if($grid->hasButtons('toolbar'))
-                        <div class="col-md-{{ $grid->getGridToolbarSize()[1] }}">
-                            <div class="pull-right">
-                                @foreach($grid->getButtons('toolbar') as $button)
-                                    {!! $button->render() !!}
-                                @endforeach
-                            </div>
-                        </div>
-                    @endif
-                <!-- end toolbar buttons -->
-                </div>
-                <!-- end search form -->
-                <!-- filter form declaration -->
-                <form action="{{ $grid->getSearchUrl() }}" method="GET" id="{{ $grid->getFilterFormId() }}"></form>
-                <!-- grid contents -->
-                <div class="table-responsive grid-wrapper">
-                    <table class="{{ $grid->getClass() }}">
-                        <thead class="{{ $grid->getHeaderClass() }}">
-                        <!-- headers -->
-                        <tr class="filter-header">
-                            @foreach($columns as $column)
+        @endif
 
-                                @if($loop->first)
+    </div>
+    <form action="{{ $grid->getSearchUrl() }}" method="GET" id="{{ $grid->getFilterFormId() }}"></form>
+    <div class="table-responsive grid-wrapper">
+        <table class="{{ $grid->getClass() }}">
+            <thead class="{{ $grid->getHeaderClass() }}">
+            <tr class="filter-header">
+                @foreach($columns as $column)
 
-                                    @if($column->isSortable)
-                                        <th scope="col"
-                                            class="{{ is_callable($column->columnClass) ? call_user_func($column->columnClass) : $column->columnClass }}"
-                                            title="click to sort by {{ $column->key }}">
-                                            <a data-trigger-pjax="1" class="data-sort"
-                                               href="{{ $grid->getSortUrl($column->key, $grid->getSelectedSortDirection()) }}">
-                                                @if($column->useRawHtmlForLabel)
-                                                    {!! $column->name !!}
-                                                @else
-                                                    {{ $column->name }}
-                                                @endif
-                                            </a>
-                                        </th>
+                    @if($loop->first)
+
+                        @if($column->isSortable)
+                            <th scope="col"
+                                class="{{ is_callable($column->columnClass) ? call_user_func($column->columnClass) : $column->columnClass }}"
+                                title="click to sort by {{ $column->key }}">
+                                <a data-trigger-pjax="1" class="data-sort"
+                                   href="{{ $grid->getSortUrl($column->key, $grid->getSelectedSortDirection()) }}">
+                                    @if($column->useRawHtmlForLabel)
+                                        {!! $column->name !!}
                                     @else
-                                        <th class="{{ is_callable($column->columnClass) ? call_user_func($column->columnClass) : $column->columnClass }}">
-                                            @if($column->useRawHtmlForLabel)
-                                                {!! $column->name !!}
-                                            @else
-                                                {{ $column->name }}
-                                            @endif
-                                        </th>
+                                        {{ $column->name }}
+                                    @endif
+                                </a>
+                            </th>
+                        @else
+                            <th class="{{ is_callable($column->columnClass) ? call_user_func($column->columnClass) : $column->columnClass }}">
+                                @if($column->useRawHtmlForLabel)
+                                    {!! $column->name !!}
+                                @else
+                                    {{ $column->name }}
+                                @endif
+                            </th>
+                        @endif
+                    @else
+                        @if($column->isSortable)
+                            <th scope="col" title="click to sort by {{ $column->key }}"
+                                class="{{ is_callable($column->columnClass) ? call_user_func($column->columnClass) : $column->columnClass }}">
+                                <a data-trigger-pjax="1" class="data-sort"
+                                   href="{{ $grid->getSortUrl($column->key, $grid->getSelectedSortDirection()) }}">
+                                    @if($column->useRawHtmlForLabel)
+                                        {!! $column->name !!}
+                                    @else
+                                        {{ $column->name }}
+                                    @endif
+                                </a>
+                            </th>
+                        @else
+                            <th scope="col"
+                                class="{{ is_callable($column->columnClass) ? call_user_func($column->columnClass) : $column->columnClass }}">
+                                @if($column->useRawHtmlForLabel)
+                                    {!! $column->name !!}
+                                @else
+                                    {{ $column->name }}
+                                @endif
+                            </th>
+                        @endif
+                    @endif
+                @endforeach
+                <th></th>
+            </tr>
+            @if($grid->shouldRenderGridFilters())
+                <tr>
+                    {!! $grid->renderGridFilters() !!}
+                </tr>
+            @endif
+            </thead>
+            <tbody>
+            @if($grid->hasItems())
+                @if($grid->warnIfEmpty())
+                    <div class="alert alert-warning" role="alert">
+                        <strong><i class="fa fa-exclamation-triangle"></i>&nbsp;No data present!.</strong>
+                    </div>
+                @endif
+            @else
+                @foreach($grid->getData() as $item)
+                    @if($grid->allowsLinkableRows())
+                        @php
+                            $callback = call_user_func($grid->getLinkableCallback(), $grid->transformName(), $item);
+                        @endphp
+                        @php
+                            $trClassCallback = call_user_func($grid->getRowCssStyle(), $grid->transformName(), $item);
+                        @endphp
+                        <tr class="{{ trim("linkable " . $trClassCallback) }}" data-url="{{ $callback }}">
+                    @else
+                        @php
+                            $trClassCallback = call_user_func($grid->getRowCssStyle(), $grid->transformName(), $item);
+                        @endphp
+                        <tr class="{{ $trClassCallback }}">
+                            @endif
+                            @foreach($columns as $column)
+                                @if(is_callable($column->data))
+                                    @if($column->useRawFormat)
+                                        <td class="{{ $column->rowClass }}">
+                                            {!! call_user_func($column->data, $item, $column->key) !!}
+                                        </td>
+                                    @else
+                                        <td class="{{ $column->rowClass }}">
+                                            {{ call_user_func($column->data , $item, $column->key) }}
+                                        </td>
                                     @endif
                                 @else
-                                    @if($column->isSortable)
-                                        <th scope="col" title="click to sort by {{ $column->key }}"
-                                            class="{{ is_callable($column->columnClass) ? call_user_func($column->columnClass) : $column->columnClass }}">
-                                            <a data-trigger-pjax="1" class="data-sort"
-                                               href="{{ $grid->getSortUrl($column->key, $grid->getSelectedSortDirection()) }}">
-                                                @if($column->useRawHtmlForLabel)
-                                                    {!! $column->name !!}
-                                                @else
-                                                    {{ $column->name }}
-                                                @endif
-                                            </a>
-                                        </th>
+                                    @if($column->useRawFormat)
+                                        <td class="{{ $column->rowClass }}">
+                                            {!! $item->{$column->key} !!}
+                                        </td>
                                     @else
-                                        <th scope="col"
-                                            class="{{ is_callable($column->columnClass) ? call_user_func($column->columnClass) : $column->columnClass }}">
-                                            @if($column->useRawHtmlForLabel)
-                                                {!! $column->name !!}
-                                            @else
-                                                {{ $column->name }}
-                                            @endif
-                                        </th>
+                                        <td class="{{ $column->rowClass }}">
+                                            {{ $item->{$column->key} }}
+                                        </td>
                                     @endif
                                 @endif
-                            @endforeach
-                            <th></th>
-                        </tr>
-                        <!-- end headers -->
-                        <!-- filters -->
-                        <tr>
-                            @include('leantony::grid.filter', ['columns' => $columns, 'formId' => $grid->getFilterFormId()])
-                        </tr>
-                        <!-- end filters -->
-                        </thead>
-                        <!-- data -->
-                        <tbody>
-                        @if($grid->hasItems())
-                            @if($grid->warnIfEmpty())
-                                <div class="alert alert-warning" role="alert">
-                                    <strong><i class="fa fa-exclamation-triangle"></i>&nbsp;No data present!.</strong>
-                                </div>
-                            @endif
-                        @else
-                            @foreach($grid->getData() as $item)
-                                @if($grid->allowsLinkableRows())
-                                    @php
-                                        $callback = call_user_func($grid->getLinkableCallback(), $grid->transformName(), $item);
-                                    @endphp
-                                    @php
-                                        $trClassCallback = call_user_func($grid->getRowCssStyle(), $grid->transformName(), $item);
-                                    @endphp
-                                    <tr class="{{ trim("linkable " . $trClassCallback) }}" data-url="{{ $callback }}">
-                                @else
-                                    @php
-                                        $trClassCallback = call_user_func($grid->getRowCssStyle(), $grid->transformName(), $item);
-                                    @endphp
-                                    <tr class="{{ $trClassCallback }}">
-                                        @endif
-                                        @foreach($columns as $column)
-                                            @if(is_callable($column->data))
-                                                @if($column->useRawFormat)
-                                                    <td class="{{ $column->rowClass }}">
-                                                        {!! call_user_func($column->data, $item, $column->key) !!}
-                                                    </td>
+                                @if($loop->last && $grid->hasButtons('rows'))
+                                    <td>
+                                        <div class="pull-right">
+                                            @foreach($grid->getButtons('rows') as $button)
+                                                @if(call_user_func($button->renderIf, $grid->transformName(), $item))
+                                                    {!! $button->render(['gridName' => $grid->transformName(), 'gridItem' => $item]) !!}
                                                 @else
-                                                    <td class="{{ $column->rowClass }}">
-                                                        {{ call_user_func($column->data , $item, $column->key) }}
-                                                    </td>
-                                                @endif
-                                            @else
-                                                @if($column->useRawFormat)
-                                                    <td class="{{ $column->rowClass }}">
-                                                        {!! $item->{$column->key} !!}
-                                                    </td>
-                                                @else
-                                                    <td class="{{ $column->rowClass }}">
-                                                        {{ $item->{$column->key} }}
-                                                    </td>
-                                                @endif
-                                            @endif
-                                            @if($loop->last && $grid->hasButtons('rows'))
-                                                <td>
-                                                    <div class="pull-right">
-                                                        @foreach($grid->getButtons('rows') as $button)
-                                                            @if(call_user_func($button->renderIf, $grid->transformName(), $item))
-                                                                {!! $button->render(['gridName' => $grid->transformName(), 'gridItem' => $item]) !!}
-                                                            @else
-                                                                @continue
-                                                            @endif
-                                                        @endforeach
-                                                    </div>
-                                                </td>
-                                            @endif
-                                        @endforeach
-                                    </tr>
-                                    @endforeach
-                                    @if($grid->shouldShowFooter())
-                                        <tr class="{{ $grid->getGridFooterClass() }}">
-                                            @foreach($columns as $column)
-                                                @if($column->footer === null)
-                                                    <td></td>
-                                                @else
-                                                    <td>
-                                                        <b>{{ call_user_func($column->footer) }}</b>
-                                                    </td>
-                                                @endif
-                                                @if($loop->last)
-                                                    <td></td>
+                                                    @continue
                                                 @endif
                                             @endforeach
-                                        </tr>
-                                    @endif
+                                        </div>
+                                    </td>
                                 @endif
-                        </tbody>
-                        <!-- end data -->
-                    </table>
-                </div>
-                <!-- end grid contents -->
-            </div>
-            <div class="card-footer">
-            @include('leantony::grid.pagination.pagination-info', ['grid' => $grid, 'direction' => 'left', 'atFooter' => true])
-            <!-- pagination -->
-                @if($grid->wantsPagination())
-                    <div class="pull-right">
-                        {{ $grid->getData()->appends(request()->query())->links($grid->getGridPaginationView(), ['pjaxTarget' => $grid->getId()]) }}
-                    </div><!-- /.center -->
-            @endif
-            <!-- end pagination -->
-            </div>
-        </div>
+                            @endforeach
+                        </tr>
+                        @endforeach
+                        @if($grid->shouldShowFooter())
+                            <tr class="{{ $grid->getGridFooterClass() }}">
+                                @foreach($columns as $column)
+                                    @if($column->footer === null)
+                                        <td></td>
+                                    @else
+                                        <td>
+                                            <b>{{ call_user_func($column->footer) }}</b>
+                                        </td>
+                                    @endif
+                                    @if($loop->last)
+                                        <td></td>
+                                    @endif
+                                @endforeach
+                            </tr>
+                        @endif
+                    @endif
+            </tbody>
+        </table>
     </div>
-</div>
+@endsection
 @push('grid_js')
     <script>
       (function($) {

--- a/src/resources/views/grid/pagination/pagination-links.blade.php
+++ b/src/resources/views/grid/pagination/pagination-links.blade.php
@@ -1,0 +1,5 @@
+@if($grid->wantsPagination())
+    <div class="pull-right">
+        {{ $grid->getData()->appends(request()->query())->links($grid->getGridPaginationView(), ['pjaxTarget' => $grid->getId()]) }}
+    </div>
+@endif

--- a/src/resources/views/grid/templates/bs4-card.blade.php
+++ b/src/resources/views/grid/templates/bs4-card.blade.php
@@ -1,0 +1,19 @@
+<div class="row laravel-grid" id="{{ $grid->getId() }}">
+    <div class="col-md-12 col-xs-12 col-sm-12">
+        <div class="card">
+            <div class="card-header">
+                <div class="pull-left">
+                    <h4 class="grid-title">{{ $grid->renderTitle() }}</h4>
+                </div>
+                {!! $grid->renderPaginationInfoAtHeader() !!}
+            </div>
+            <div class="card-body">
+                @yield('data')
+            </div>
+            <div class="card-footer">
+                {!! $grid->renderPaginationInfoAtFooter() !!}
+                {!! $grid->renderPaginationLinksSection() !!}
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/resources/views/grid/templates/dummy.blade.php
+++ b/src/resources/views/grid/templates/dummy.blade.php
@@ -1,0 +1,8 @@
+<div class="row laravel-grid" id="{{ $grid->getId() }}">
+    <div class="col-md-12 col-xs-12 col-sm-12">
+        <h2>{{ $grid->renderTitle() }}</h2>
+        <p>dummy</p>
+        @yield('data')
+        {!! $grid->renderPaginationLinksSection() !!}
+    </div>
+</div>

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -145,13 +145,94 @@ class PackageTest extends TestCase
      * @test
      * @throws \Throwable
      */
-    public function grid_can_disable_rendering_of_search_form()
+    public function grid_can_disable_rendering_of_filters()
+    {
+        $grid = $this->getGridInstances()['users_default'];
+        /** @var $grid UsersGrid */
+        $grid->withoutFilters();
+        // a sample filter that's enabled on the grid
+        $usersFilterId = 'grid-filter-user';
+        $content = $grid->render();
+        $this->assertNotContains("${usersFilterId}", $content);
+    }
+
+    /**
+     * @throws \Exception
+     * @test
+     * @throws \Throwable
+     */
+    public function grid_can_enable_rendering_of_filters()
+    {
+        $grid = $this->getGridInstances()['users_default'];
+        /** @var $grid UsersGrid */
+        // the grid filter form id
+        $gridFilterFormId = 'user-grid-filter';
+        // a sample filter that's enabled on the grid
+        $usersFilterId = 'grid-filter-name';
+        $content = $grid->render();
+        $this->assertContains("${gridFilterFormId}", $content);
+        $this->assertContains("${usersFilterId}", $content);
+    }
+
+    /**
+     * @throws \Exception
+     * @test
+     * @throws \Throwable
+     */
+    public function grid_can_enable_rendering_of_search()
+    {
+        $grid = $this->getGridInstances()['users_default'];
+        /** @var $grid UsersGrid */
+        $id = 'search-user-grid';
+        $content = $grid->render();
+        $this->assertContains("${id}", $content);
+    }
+
+    /**
+     * @throws \Exception
+     * @test
+     * @throws \Throwable
+     */
+    public function grid_can_disable_rendering_of_search()
     {
         $grid = $this->getGridInstances()['users_default'];
         /** @var $grid UsersGrid */
         $grid->withoutSearchForm();
-        $id = $grid->getId();
+        $id = 'search-user-grid';
         $content = $grid->render();
-        $this->assertNotContains("<form method='GET' id=\"${id}\"", $content);
+        $this->assertNotContains("${id}", $content);
+    }
+
+    /**
+     * @throws \Exception
+     * @test
+     * @throws \Throwable
+     */
+    public function grid_can_render_using_default_layout()
+    {
+        // default scenario
+        $grid = $this->getGridInstances()['users_default'];
+        /** @var $grid UsersGrid */
+        $content = $grid->render();
+        // default layout uses a bootstrap4 card
+        $this->assertContains("card-header", $content);
+        $this->assertContains("card-body", $content);
+        $this->assertContains("card-footer", $content);
+    }
+
+    /**
+     * @throws \Exception
+     * @test
+     * @throws \Throwable
+     */
+    public function grid_can_render_using_custom_layout()
+    {
+        // using custom template
+        $grid = $this->getGridInstances()['users_default'];
+        /** @var $grid UsersGrid */
+        $grid->withCustomTemplate('leantony::grid.templates.dummy');
+        $content = $grid->render();
+        // default layout uses a bootstrap4 card
+        $this->assertContains("dummy", $content);
     }
 }


### PR DESCRIPTION
Address #57 
# sample layout is a bootstrap 4 card.
```php
<div class="row laravel-grid" id="{{ $grid->getId() }}">
    <div class="col-md-12 col-xs-12 col-sm-12">
        <div class="card">
            <div class="card-header">
                <div class="pull-left">
                    <h4 class="grid-title">{{ $grid->renderTitle() }}</h4>
                </div>
                {!! $grid->renderPaginationInfoAtHeader() !!}
            </div>
            <div class="card-body">
                @yield('data')
            </div>
            <div class="card-footer">
                {!! $grid->renderPaginationInfoAtFooter() !!}
                {!! $grid->renderPaginationLinksSection() !!}
            </div>
        </div>
    </div>
</div>
```
The grid itself will be inserted at the `data` section. To customize the template, i've added an extra key to the config file
```php
/**
     * Grid templates
     */
    'templates' => [
        /**
         * The view to use for the templates
         */
        'view' => 'leantony::grid.templates.bs4-card'
    ]
```
As you can see, changing the view to use for the layout should be easy. The variables in the card template are not mandatory. You can tweak the view the way you want it to be.
**However**, since the grid uses PJAX, you might as well ensure that you have the ID of the grid's container set. Otherwise, you'll get javascript errors. The layout should start like this;
```html
<div class="row laravel-grid" id="{{ $grid->getId() }}">
```
The class `laravel-grid` is used to apply some preset classes to the HTML elements within the grid, so it is also needed.
You can also set this functionality per grid, by calling the `withCustomTemplate` function when creating your grid. Like this;
```php
$someGrid->create(['query' => User::query(), 'request' => $request])->withCustomTemplate('view_name')
```
Alternatively, you can override the `getRenderingTemplateToUse` function. By default, it gets the view set in configuration.
```php
/**
     * Get the rendering template/grid layout to use
     *
     * @return string
     */
    public function getRenderingTemplateToUse(): string
    {
        return $this->getGridTemplateView();
    }
```
Setting the view on the config file will make the layout/template apply to all grids created.