### PR TITLE
add ability to add custom title for grid filter

### DIFF
--- a/src/Filters/GenericFilter.php
+++ b/src/Filters/GenericFilter.php
@@ -158,9 +158,13 @@ class GenericFilter implements Htmlable
             case 'text':
                 // all filters apart from dropdowns are rendered as text elements.
                 // css classes or js libraries can be used to change this
-                return view('leantony::grid.filters.text', $this->compactData(func_get_args()))->render();
+                return view('leantony::grid.filters.text', $this->compactData(
+                    array_collapse(func_get_args())
+                ))->render();
             case 'select':
-                return view('leantony::grid.filters.dropdown', $this->compactData(func_get_args()))->render();
+                return view('leantony::grid.filters.dropdown', $this->compactData(
+                    array_collapse(func_get_args())
+                ))->render();
             default:
                 throw new \Exception("Unknown filter type.");
         }

--- a/src/Listeners/AddExtraAttributesToProcessedColumn.php
+++ b/src/Listeners/AddExtraAttributesToProcessedColumn.php
@@ -34,6 +34,8 @@ class AddExtraAttributesToProcessedColumn
 
         $this->addHtmlCheckForLabel($data, $col);
 
+        $this->addTitleForFilter($data, $col);
+
         // make sure the column object is returned
         return $col;
     }
@@ -53,5 +55,23 @@ class AddExtraAttributesToProcessedColumn
         }
 
         $col->useRawHtmlForLabel = $useRawHtmlForLabel;
+    }
+
+    /**
+     * Add title for filter. This will not be used if not set
+     * So, the default one set on the filter will be used if this one is unavailable
+     *
+     * @param $columnData
+     * @param $col
+     */
+    public function addTitleForFilter($columnData, $col): void
+    {
+        if (isset($columnData['filter'])) {
+            $filterTitle = $columnData['filter']['title'] ?? null;
+        } else {
+            $filterTitle = null;
+        }
+
+        $col->filterTitle = $filterTitle;
     }
 }

--- a/src/resources/views/grid/filter.blade.php
+++ b/src/resources/views/grid/filter.blade.php
@@ -1,11 +1,11 @@
-@foreach($columns as $row)
-    @if(!$row->filter)
+@foreach($columns as $col)
+    @if(!$col->filter)
         <th></th>
-    @elseif(!$row->filter->enabled)
+    @elseif(!$col->filter->enabled)
         <th></th>
     @else
         <th>
-            {!! $row->filter !!}
+            {!! $col->filter->render(['titleSetOnColumn' => $col->filterTitle]) !!}
         </th>
     @endif
     @if($loop->last)

--- a/src/resources/views/grid/filters/text.blade.php
+++ b/src/resources/views/grid/filters/text.blade.php
@@ -1,6 +1,6 @@
 <input type="text" name="{{ $name }}" id="{{ $id }}"
        form="{{ $formId }}"
-       class="{{ $class }}" value="{{ request($name) }}" title="{{ $title }}" placeholder="{{ $title }}"
+       class="{{ $class }}" value="{{ request($name) }}" title="{{ $title }}" placeholder="{{ $titleSetOnColumn ?? $title }}"
        @foreach($dataAttributes as $k => $v)
        data-{{ $k }}={{ $v }}
         @endforeach

--- a/src/resources/views/grid/filters/text.blade.php
+++ b/src/resources/views/grid/filters/text.blade.php
@@ -1,6 +1,6 @@
 <input type="text" name="{{ $name }}" id="{{ $id }}"
        form="{{ $formId }}"
-       class="{{ $class }}" value="{{ request($name) }}" title="{{ $title }}" placeholder="{{ $titleSetOnColumn ?? $title }}"
+       class="{{ $class }}" value="{{ request($name) }}" title="{{ $titleSetOnColumn ?? $title }}" placeholder="{{ $titleSetOnColumn ?? $title }}"
        @foreach($dataAttributes as $k => $v)
        data-{{ $k }}={{ $v }}
         @endforeach

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -235,4 +235,18 @@ class PackageTest extends TestCase
         // default layout uses a bootstrap4 card
         $this->assertContains("dummy", $content);
     }
+
+    /**
+     * @throws \Throwable
+     * @test
+     */
+    public function grid_can_add_custom_filter_titles()
+    {
+        $filterText = "filter-by-foo-bar";
+        $grid = $this->getGridInstances()['users_customized'];
+        /** @var $grid UsersGrid */
+        $content = $grid->render();
+
+        $this->assertContains($filterText, $content);
+    }
 }

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -243,10 +243,14 @@ class PackageTest extends TestCase
     public function grid_can_add_custom_filter_titles()
     {
         $filterText = "filter-by-foo-bar";
+        $existingFilterTextSampleNotExisting = "filter by name";
+        $existingFilterTextSampleExisting = "filter by created_at";
         $grid = $this->getGridInstances()['users_customized'];
         /** @var $grid UsersGrid */
         $content = $grid->render();
 
         $this->assertContains($filterText, $content);
+        $this->assertContains($existingFilterTextSampleExisting, $content);
+        $this->assertNotContains($existingFilterTextSampleNotExisting, $content);
     }
 }

--- a/tests/Setup/Grids/UsersGridCustomized.php
+++ b/tests/Setup/Grids/UsersGridCustomized.php
@@ -46,6 +46,7 @@ class UsersGridCustomized extends Grid implements UsersGridInterface
 		    "id" => [
 		        "label" => "ID",
 		        "filter" => [
+		            "title" => "filter-by-foo-bar",
 		            "enabled" => true,
 		            "operator" => "="
 		        ],


### PR DESCRIPTION
To customize the title for the grid's filter, simply add a `title` attribute to your grid. This will add the custom title to the filter's `placeholder` and `title` HTML attributes.

```php
"id" => [
	"label" => "ID",
	"filter" => [
	    "title" => "filter-by-foo-bar",
	    "enabled" => true,
        ]
]
```