### PR TITLE
Bugfix : display search form only if shouldRenderSearchForm is true

### DIFF
--- a/src/resources/views/grid/grid.blade.php
+++ b/src/resources/views/grid/grid.blade.php
@@ -16,7 +16,9 @@
         @endif
 
     </div>
+    @if($grid->shouldRenderSearchForm())
     <form action="{{ $grid->getSearchUrl() }}" method="GET" id="{{ $grid->getFilterFormId() }}"></form>
+    @endif
     <div class="table-responsive grid-wrapper">
         <table class="{{ $grid->getClass() }}">
             <thead class="{{ $grid->getHeaderClass() }}">


### PR DESCRIPTION
@leantony small bugfix : 
We should not show the search form if search is disabled.

It is useless, but It can also cause trouble if we add a grid (with search disabled) inside another form.